### PR TITLE
Fix SubscriberProtocol hanging with authentication

### DIFF
--- a/txredisapi.py
+++ b/txredisapi.py
@@ -1711,7 +1711,7 @@ class SubscriberProtocol(RedisProtocol):
                 self.messageReceived(*reply[-3:])
             else:
                 self.replyQueue.put(reply[-3:])
-        elif isinstance(reply, Exception):
+        else:
             self.replyQueue.put(reply)
 
     def subscribe(self, channels):


### PR DESCRIPTION
When RedisFactory is used in conjunction with SubscriberProtocol and a Redis password or dbid, SubscriberProtocol swallowed the response causing the factory never to fire its Deferred.

Fixes #85