### PR TITLE
Fixed hanging if new connection is made after disconnect() call

### DIFF
--- a/txredisapi.py
+++ b/txredisapi.py
@@ -2139,6 +2139,10 @@ class RedisFactory(protocol.ReconnectingClientFactory):
         return p
 
     def addConnection(self, conn):
+        if not self.continueTrying:
+            conn.transport.loseConnection()
+            return
+
         self.connectionQueue.put(conn)
         self.pool.append(conn)
         self.size = len(self.pool)


### PR DESCRIPTION
`ConnectionPool` may hang on disconnecting if new connection is made after `disconnect()` call. This new connection is added to `pool`, but it wont disconnect, so pool will never be empty and `disconnect()` will never return.

This happen often when I run very short unit tests and when not all pool's connections get connected before `disconnect()`.

Fixed by preventing new connections to be added to pool if its `continueTrying` is set to `False`.