### PR TITLE
Fixed reconnect=False, broken by 5469ca1b

### DIFF
--- a/txredisapi.py
+++ b/txredisapi.py
@@ -1828,6 +1828,7 @@ class ConnectionHandler(object):
 
     def disconnect(self):
         self._factory.continueTrying = 0
+        self._factory.disconnectCalled = True
         for conn in self._factory.pool:
             try:
                 conn.transport.loseConnection()
@@ -2133,6 +2134,7 @@ class RedisFactory(protocol.ReconnectingClientFactory):
         self.handler = handler(self)
         self.connectionQueue = defer.DeferredQueue()
         self._waitingForEmptyPool = set()
+        self.disconnectCalled = False
 
     def buildProtocol(self, addr):
         if hasattr(self, 'charset'):
@@ -2144,7 +2146,7 @@ class RedisFactory(protocol.ReconnectingClientFactory):
         return p
 
     def addConnection(self, conn):
-        if not self.continueTrying:
+        if self.disconnectCalled:
             conn.transport.loseConnection()
             return
 


### PR DESCRIPTION
Sorry, I broke `reconnect=False` parameter of Connections by my previous commit c64c8101d9d5467d7e6b50619be94b069c290c6a
It turns out that `continueTrying` is overloaded to implement one-shot connections and for them it is always `False`.

Sorry :(