### PR TITLE
Make `hexists` to return bool

### DIFF
--- a/txredisapi.py
+++ b/txredisapi.py
@@ -1378,7 +1378,7 @@ class BaseRedisProtocol(LineReceiver, policies.TimeoutMixin):
         """
         Test for existence of a specified field in a hash
         """
-        return self.execute_command("HEXISTS", key, field)
+        return self.execute_command("HEXISTS", key, field).addCallback(bool)
 
     def hdel(self, key, fields):
         """


### PR DESCRIPTION
Redis doesn't have distinct boolean data type, so its boolean queries return integer 1/0. But we in python do have one and it makes sense to return `bool` where appropriate. This is already done for `smove` and `sismember`, so I suggest to convert result `hexists` to `bool` as well.

This shouldn't break any existing code even if someone used result of `hexists` in some sort of arithmetics because `bool` is gracefully compatible with `int(1)`.