### PR TITLE
Fixed handling of multiple responses to sub/unsub commands

### DIFF
--- a/txredisapi.py
+++ b/txredisapi.py
@@ -1845,6 +1845,8 @@ class MonitorProtocol(RedisProtocol):
 
 
 class SubscriberProtocol(RedisProtocol):
+    _sub_unsub_reponses = set([u"subscribe", u"unsubscribe", u"psubscribe", u"punsubscribe"])
+
     def messageReceived(self, pattern, channel, message):
         pass
 
@@ -1854,6 +1856,8 @@ class SubscriberProtocol(RedisProtocol):
                 self.messageReceived(None, *reply[-2:])
             elif len(reply) > 3 and reply[-4] == u"pmessage":
                 self.messageReceived(*reply[-3:])
+            elif reply[-3] in self._sub_unsub_reponses and len(self.replyQueue.waiting) == 0:
+                pass
             else:
                 self.replyQueue.put(reply[-3:])
         else:


### PR DESCRIPTION
I'm using `txredisapi` in application which do tons of `subscribe`/`unsubscribe` with multiple channel names and I noticed that memory consumption is constantly growing.

It turns out that `subscribe`/`unsubscribe`/`psubscribe`/`punsubscribe` commands produces N distinct response messages from Redis server when called with N arguments. This is a kind of strange, but pub/sub is the place where Redis deviates from normal request-response scheme anyways.

Proof:
```
ilya ~ > telnet localhost 6379
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
subscribe qwe asd zxc
*3
$9
subscribe
$3
qwe
:1
*3
$9
subscribe
$3
asd
:2
*3
$9
subscribe
$3
zxc
:3
^]
telnet> close
Connection closed.
```

When client calls `subscribe(["channel-1", "channel-2"])`, Redis produces 2 reponses. The first is handled by [`execute_command`](https://github.com/fiorix/txredisapi/blob/master/txredisapi.py#L560) as usual, but the second is put into `replyQueue` by [`replyReceived`](https://github.com/fiorix/txredisapi/blob/master/txredisapi.py#L1858) and never gets back. So when there are many such commands, `replyQueue` is growing indefinitely.

This patch changes `replyReceived` so it won't push unsolicited `sub`/`unsub`/`psub`/`punsub` responses into `replyQueue` if there are no waiters for it. So the first response will be handled by `execute_command` as usual, but the rest will be dismissed.

Another approach could be to override `execute_command` and get N responses from the queue. But this sounds more complex.